### PR TITLE
Fixed the slippage validation logic according to swap market pair

### DIFF
--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1

--- a/fuzzer/src/fuzz.rs
+++ b/fuzzer/src/fuzz.rs
@@ -17,7 +17,7 @@
 use sp_arithmetic::Permill;
 use std::str::FromStr;
 use tidefi_primitives::{
-  assert_swap_work, assets::Asset, AccountId, BlockNumber, SlippageError, Swap, SwapStatus,
+  assert_swap_work, assets::Asset, AccountId, BlockNumber, MarketPair, SlippageError, Swap, SwapStatus,
   SwapType,
 };
 const ALICE: &str = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
@@ -72,7 +72,11 @@ fn run_one_swap(data: (u16, u16)) {
     market_order,
     limit_order,
     market_maker_amount_to_receive,
-    market_maker_amount_to_send
+    market_maker_amount_to_send,
+    MarketPair {
+      base_asset: Asset::Tdfy.currency_id(),
+      quote_asset: Asset::Bitcoin.currency_id(),
+    }
   );
 }
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tidefi-primitives"
 authors = ["Semantic Network Team <publishers@tidelabs.org>"]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/primitives/src/swap/swap.rs
+++ b/primitives/src/swap/swap.rs
@@ -113,8 +113,8 @@ pub struct Swap<AccountId, BlockNumber> {
 }
 
 /// Swap market pair details stored on-chain.
-#[derive(Eq, PartialEq, Encode, Decode, TypeInfo, MaxEncodedLen, Clone)]
-#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Encode, Decode, Debug, TypeInfo, MaxEncodedLen, Clone)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct MarketPair {
   /// Base asset of the swap market pair

--- a/primitives/src/swap/swap.rs
+++ b/primitives/src/swap/swap.rs
@@ -116,7 +116,7 @@ pub struct Swap<AccountId, BlockNumber> {
 #[derive(Eq, PartialEq, Encode, Decode, TypeInfo, MaxEncodedLen, Clone)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub struct MarketPair<CurrencyId> {
+pub struct MarketPair {
   /// Base asset of the swap market pair
   pub base_asset: CurrencyId,
   /// Quote asset of the swap market pair
@@ -142,7 +142,7 @@ pub enum SlippageError {
 impl<AccountId: Clone, BlockNumber: Clone> Swap<AccountId, BlockNumber> {
   pub fn pay_per_token_lower_bond(
     &self,
-    market_pair: &MarketPair<CurrencyId>,
+    market_pair: &MarketPair,
   ) -> Result<FixedU128, SlippageError> {
     if self.token_from == market_pair.base_asset {
       // selling
@@ -165,7 +165,7 @@ impl<AccountId: Clone, BlockNumber: Clone> Swap<AccountId, BlockNumber> {
 
   pub fn pay_per_token_upper_bond(
     &self,
-    market_pair: &MarketPair<CurrencyId>,
+    market_pair: &MarketPair,
   ) -> Result<FixedU128, SlippageError> {
     if self.token_to == market_pair.base_asset {
       // buying
@@ -190,7 +190,7 @@ impl<AccountId: Clone, BlockNumber: Clone> Swap<AccountId, BlockNumber> {
     &self,
     base_amount_closure: FT,
     quote_amount_closure: FF,
-    market_pair: &MarketPair<CurrencyId>,
+    market_pair: &MarketPair,
     base_amount: Balance,
     quote_amount: Balance,
   ) -> Result<FixedU128, SlippageError>
@@ -222,7 +222,7 @@ impl<AccountId: Clone, BlockNumber: Clone> Swap<AccountId, BlockNumber> {
   fn validate_slippage_dry_run(
     &self,
     price_offered: FixedU128,
-    market_pair: &MarketPair<CurrencyId>,
+    market_pair: &MarketPair,
   ) -> Result<(), SlippageError> {
     if self.token_to == market_pair.base_asset {
       // buyer should not accept a price greater than upper bound
@@ -260,7 +260,7 @@ impl<AccountId: Clone, BlockNumber: Clone> Swap<AccountId, BlockNumber> {
     market_maker_swap: &Swap<AccountId, BlockNumber>,
     offered_base_amount: Balance,
     offered_quote_amount: Balance,
-    market_pair: &MarketPair<CurrencyId>,
+    market_pair: &MarketPair,
   ) -> Result<(), SlippageError> {
     let base_asset: Asset = market_pair
       .base_asset
@@ -288,7 +288,7 @@ impl<AccountId: Clone, BlockNumber: Clone> Swap<AccountId, BlockNumber> {
   }
 }
 
-impl MarketPair<CurrencyId> {
+impl MarketPair {
   pub fn is_selling(&self, swap: &Swap<AccountId, BlockNumber>) -> Result<bool, SlippageError> {
     if swap.token_from == self.base_asset {
       Ok(true)

--- a/primitives/src/swap/swap.rs
+++ b/primitives/src/swap/swap.rs
@@ -252,8 +252,8 @@ impl<AccountId: Clone, BlockNumber: Clone> Swap<AccountId, BlockNumber> {
   /// Validate slippage
   ///
   /// * `market_maker_swap` - Market maker (limit order) to test against.
-  /// * `market_maker_amount_to_receive` - Expected amount the limit order will receive against `market_maker_amount_to_send`.
-  /// * `market_maker_amount_to_send` - Expected amount the market order will receive against `market_maker_amount_to_receive`.
+  /// * `offered_base_amount` - Base asset amount in the offer
+  /// * `offered_quote_amount` - Quote asset amount in the offer
   /// * `market_pair` - Market pair that this swap belongs to
   pub fn validate_slippage(
     &self,

--- a/primitives/src/swap/swap.rs
+++ b/primitives/src/swap/swap.rs
@@ -15,7 +15,7 @@
 // along with tidefi-primitives.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-  Asset, Balance, CurrencyId, Decode, Encode, FixedU128, Hash, MaxEncodedLen, Permill, TypeInfo,
+  AccountId, Asset, Balance, BlockNumber, CurrencyId, Decode, Encode, FixedU128, Hash, MaxEncodedLen, Permill, TypeInfo,
 };
 use codec::alloc::string::String;
 use sp_arithmetic::{traits::CheckedDiv, FixedPointNumber};
@@ -111,144 +111,131 @@ pub struct Swap<AccountId, BlockNumber> {
   pub slippage: Permill,
 }
 
+/// Swap market pair details stored on-chain.
+#[derive(Eq, PartialEq, Encode, Decode, TypeInfo, MaxEncodedLen, Clone)]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+pub struct MarketPair<CurrencyId> {
+  /// Base asset of the swap market pair
+  pub base_asset: CurrencyId,
+  /// Quote asset of the swap market pair
+  pub quote_asset: CurrencyId,
+}
+
 #[derive(Eq, PartialEq, Encode, Decode, TypeInfo, MaxEncodedLen, Clone)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum SlippageError {
   UnknownAsset,
+  UnknownAssetInMarketPair,
   SlippageOverflow,
   ArithmeticError,
   OfferIsLessThanSwapLowerBound,
   OfferIsGreaterThanSwapUpperBound,
   OfferIsLessThanMarketMakerSwapLowerBound,
   OfferIsGreaterThanMarketMakerSwapUpperBound,
+  NoLowerBoundForBuying,
+  NoUpperBoundForSelling,
 }
 
 impl<AccountId: Clone, BlockNumber: Clone> Swap<AccountId, BlockNumber> {
-  pub fn pay_per_token_lower_bond(&self) -> Result<FixedU128, SlippageError> {
-    Ok(
-      self
-        .pay_per_token(
-          |amount_to| {
-            amount_to
-              .checked_sub(self.slippage * amount_to)
+  pub fn pay_per_token_lower_bond(&self, market_pair: &MarketPair<CurrencyId>) -> Result<FixedU128, SlippageError> {
+    if self.token_from == market_pair.base_asset { // selling
+      return Ok(
+        self.pay_per_token(
+          |base_amount| base_amount,
+          |quote_amount| {
+            quote_amount
+              .checked_sub(self.slippage * quote_amount)
               .ok_or(SlippageError::ArithmeticError)
-              .unwrap_or(amount_to)
+              .unwrap_or(quote_amount)
           },
-          |amount_from| amount_from,
+          market_pair,
+          self.amount_from,
+          self.amount_to,          
         )?
-        .min(self.pay_per_token(
-          |amount_to| amount_to,
-          |amount_from| {
-            amount_from
-              .checked_add(self.slippage * amount_from)
-              .ok_or(SlippageError::ArithmeticError)
-              .unwrap_or(amount_from)
-          },
-        )?),
-    )
+      );
+    }
+    
+    Err(SlippageError::NoLowerBoundForBuying)
   }
 
-  pub fn pay_per_token_upper_bond(&self) -> Result<FixedU128, SlippageError> {
-    Ok(
-      self
-        .pay_per_token(
-          |amount_to| {
-            amount_to
-              .checked_add(self.slippage * amount_to)
+  pub fn pay_per_token_upper_bond(&self, market_pair: &MarketPair<CurrencyId>) -> Result<FixedU128, SlippageError> {
+    if self.token_to == market_pair.base_asset { // buying
+      return Ok(
+        self.pay_per_token(
+          |base_amount| base_amount,
+          |quote_amount| {
+            quote_amount
+              .checked_add(self.slippage * quote_amount)
               .ok_or(SlippageError::ArithmeticError)
-              .unwrap_or(amount_to)
+              .unwrap_or(quote_amount)
           },
-          |amount_from| amount_from,
+          market_pair,
+          self.amount_to,
+          self.amount_from,
         )?
-        .max(self.pay_per_token(
-          |amount_to| amount_to,
-          |amount_from| {
-            amount_from
-              .checked_sub(self.slippage * amount_from)
-              .ok_or(SlippageError::ArithmeticError)
-              .unwrap_or(amount_from)
-          },
-        )?),
-    )
+      );
+    }
+
+    Err(SlippageError::NoUpperBoundForSelling)
   }
 
   fn pay_per_token<FT, FF>(
     &self,
-    amount_to_closure: FT,
-    amount_from_closure: FF,
+    base_amount_closure: FT,
+    quote_amount_closure: FF,
+    market_pair: &MarketPair<CurrencyId>,
+    base_amount: Balance,
+    quote_amount: Balance,
   ) -> Result<FixedU128, SlippageError>
   where
     FT: Fn(Balance) -> Balance,
     FF: Fn(Balance) -> Balance,
   {
-    let token_to: Asset = self
-      .token_to
+    let base_asset: Asset = market_pair.base_asset
       .try_into()
       .map_err(|_| SlippageError::UnknownAsset)?;
 
-    let token_to_one_unit = token_to.saturating_mul(1);
+    let base_token_one_unit = base_asset.saturating_mul(1);
 
-    let token_from: Asset = self
-      .token_from
+    let quote_asset: Asset = market_pair.quote_asset
       .try_into()
       .map_err(|_| SlippageError::UnknownAsset)?;
-    let token_from_one_unit = token_from.saturating_mul(1);
+    let quote_token_one_unit = quote_asset.saturating_mul(1);
 
-    FixedU128::saturating_from_rational(amount_to_closure(self.amount_to), token_to_one_unit)
+    FixedU128::saturating_from_rational(quote_amount_closure(quote_amount), quote_token_one_unit)
       .checked_div(&FixedU128::saturating_from_rational(
-        amount_from_closure(self.amount_from),
-        token_from_one_unit,
+        base_amount_closure(base_amount),
+        base_token_one_unit
       ))
       .ok_or(SlippageError::SlippageOverflow)
   }
 
   fn validate_slippage_dry_run(
     &self,
-    amount_to_receive: Balance,
-    amount_to_send: Balance,
+    price_offered: FixedU128,
+    market_pair: &MarketPair<CurrencyId>,
   ) -> Result<(), SlippageError> {
-    let token_to: Asset = self
-      .token_to
-      .try_into()
-      .map_err(|_| SlippageError::UnknownAsset)?;
-
-    let token_to_one_unit = token_to.saturating_mul(1);
-
-    let token_from: Asset = self
-      .token_from
-      .try_into()
-      .map_err(|_| SlippageError::UnknownAsset)?;
-    let token_from_one_unit = token_from.saturating_mul(1);
-
-    let pay_per_token_lower_bond = self.pay_per_token_lower_bond()?;
-    let pay_per_token_upper_bond = self.pay_per_token_upper_bond()?;
-
-    let pay_per_token_offered =
-      FixedU128::saturating_from_rational(amount_to_receive, token_to_one_unit)
-        .checked_div(&FixedU128::saturating_from_rational(
-          amount_to_send,
-          token_from_one_unit,
-        ))
-        .ok_or(SlippageError::SlippageOverflow)?;
-
-    // limit order can match with smaller price
-    if self.swap_type != SwapType::Limit {
-      if pay_per_token_offered.lt(&pay_per_token_lower_bond) {
+    if self.token_to == market_pair.base_asset { // buyer should not accept a price greater than upper bound
+      let pay_per_token_upper_bond = self.pay_per_token_upper_bond(market_pair)?;
+      if price_offered.gt(&pay_per_token_upper_bond) {
+        if self.is_market_maker {
+          return Err(SlippageError::OfferIsGreaterThanMarketMakerSwapUpperBound);
+        } else {
+          return Err(SlippageError::OfferIsGreaterThanSwapUpperBound);
+        }
+      }
+    } 
+    else {
+      let pay_per_token_lower_bond = self.pay_per_token_lower_bond(market_pair)?;
+      if price_offered.lt(&pay_per_token_lower_bond) { // seller should not accept a price smaller than lower bound
         if self.is_market_maker {
           return Err(SlippageError::OfferIsLessThanMarketMakerSwapLowerBound);
         } else {
           return Err(SlippageError::OfferIsLessThanSwapLowerBound);
         }
-      }
-    }
-
-    if pay_per_token_offered.gt(&pay_per_token_upper_bond) {
-      if self.is_market_maker {
-        return Err(SlippageError::OfferIsGreaterThanMarketMakerSwapUpperBound);
-      } else {
-        return Err(SlippageError::OfferIsGreaterThanSwapUpperBound);
-      }
+      } 
     }
 
     Ok(())
@@ -259,15 +246,47 @@ impl<AccountId: Clone, BlockNumber: Clone> Swap<AccountId, BlockNumber> {
   /// * `market_maker_swap` - Market maker (limit order) to test against.
   /// * `market_maker_amount_to_receive` - Expected amount the limit order will receive against `market_maker_amount_to_send`.
   /// * `market_maker_amount_to_send` - Expected amount the market order will receive against `market_maker_amount_to_receive`.
+  /// * `market_pair` - Market pair that this swap belongs to
   pub fn validate_slippage(
     &self,
     market_maker_swap: &Swap<AccountId, BlockNumber>,
-    market_maker_amount_to_receive: Balance,
-    market_maker_amount_to_send: Balance,
+    offered_base_amount: Balance,
+    offered_quote_amount: Balance,
+    market_pair: &MarketPair<CurrencyId>,
   ) -> Result<(), SlippageError> {
-    self.validate_slippage_dry_run(market_maker_amount_to_send, market_maker_amount_to_receive)?;
+    let base_asset: Asset = market_pair.base_asset
+      .try_into()
+      .map_err(|_| SlippageError::UnknownAsset)?;
+    let base_asset_one_unit = base_asset.saturating_mul(1);
+
+    let quote_asset: Asset = market_pair.quote_asset
+      .try_into()
+      .map_err(|_| SlippageError::UnknownAsset)?;
+    let quote_asset_one_unit = quote_asset.saturating_mul(1);
+
+    let price_offered = 
+      FixedU128::saturating_from_rational(offered_quote_amount, quote_asset_one_unit)
+      .checked_div(&FixedU128::saturating_from_rational(
+        offered_base_amount,
+        base_asset_one_unit,
+      ))
+      .ok_or(SlippageError::SlippageOverflow)?;
+
+    self.validate_slippage_dry_run(price_offered, market_pair)?;
 
     market_maker_swap
-      .validate_slippage_dry_run(market_maker_amount_to_receive, market_maker_amount_to_send)
+      .validate_slippage_dry_run(price_offered, market_pair)
+  }
+}
+
+impl MarketPair<CurrencyId> {
+  pub fn is_selling (&self, swap: &Swap<AccountId, BlockNumber>) -> Result<bool, SlippageError> {
+    if swap.token_from == self.base_asset{
+      Ok(true)
+    } else if swap.token_from == self.quote_asset {
+      Ok(false)
+    } else {
+      Err(SlippageError::UnknownAssetInMarketPair)
+    }
   }
 }

--- a/primitives/src/swap/test.rs
+++ b/primitives/src/swap/test.rs
@@ -19,10 +19,14 @@ macro_rules! assert_swap_work {
   ($market_order:expr, $limit_order:expr, $offer_base_amount:expr, $offer_quote_amount:expr, $market_pair:expr) => {{
     let one_percent = Permill::from_rational(1_u128, 100_u128);
     let one_millionth = Permill::from_rational(1_u128, 1_000_000_u128);
-    let offer_quote_amount_1percent_more = $offer_quote_amount.saturating_add(one_percent * $offer_quote_amount);
-    let offer_quote_amount_1percent_less = $offer_quote_amount.saturating_sub(one_percent * $offer_quote_amount);
-    let offer_quote_amount_excceded_upperbound = offer_quote_amount_1percent_more.saturating_add(one_millionth * $offer_quote_amount);
-    let offer_quote_amount_excceded_lowerbound = offer_quote_amount_1percent_less.saturating_sub(one_millionth * $offer_quote_amount);
+    let offer_quote_amount_1percent_more =
+      $offer_quote_amount.saturating_add(one_percent * $offer_quote_amount);
+    let offer_quote_amount_1percent_less =
+      $offer_quote_amount.saturating_sub(one_percent * $offer_quote_amount);
+    let offer_quote_amount_excceded_upperbound =
+      offer_quote_amount_1percent_more.saturating_add(one_millionth * $offer_quote_amount);
+    let offer_quote_amount_excceded_lowerbound =
+      offer_quote_amount_1percent_less.saturating_sub(one_millionth * $offer_quote_amount);
 
     // should pass with exact numbers
     assert_eq!(
@@ -65,12 +69,16 @@ macro_rules! assert_swap_work {
         offer_quote_amount_excceded_lowerbound,
         &$market_pair,
       ),
-      if ($market_pair.is_selling(&$limit_order).expect("market pair should be found in swap")
+      if ($market_pair
+        .is_selling(&$limit_order)
+        .expect("market pair should be found in swap")
         && $limit_order.is_market_maker)
-        || ($market_pair.is_selling(&$market_order).expect("market pair should be found in swap")
-        && $market_order.is_market_maker)
+        || ($market_pair
+          .is_selling(&$market_order)
+          .expect("market pair should be found in swap")
+          && $market_order.is_market_maker)
       {
-        Err(SlippageError::OfferIsLessThanMarketMakerSwapLowerBound)  
+        Err(SlippageError::OfferIsLessThanMarketMakerSwapLowerBound)
       } else {
         Err(SlippageError::OfferIsLessThanSwapLowerBound)
       }
@@ -84,10 +92,14 @@ macro_rules! assert_swap_work {
         offer_quote_amount_excceded_upperbound,
         &$market_pair,
       ),
-      if (!$market_pair.is_selling(&$limit_order).expect("market pair should be found in swap")
+      if (!$market_pair
+        .is_selling(&$limit_order)
+        .expect("market pair should be found in swap")
         && $limit_order.is_market_maker)
-        || (!$market_pair.is_selling(&$market_order).expect("market pair should be found in swap")
-        && $market_order.is_market_maker)
+        || (!$market_pair
+          .is_selling(&$market_order)
+          .expect("market pair should be found in swap")
+          && $market_order.is_market_maker)
       {
         Err(SlippageError::OfferIsGreaterThanMarketMakerSwapUpperBound)
       } else {
@@ -159,8 +171,16 @@ mod tests {
           one_percent,
         );
 
-        let offer_base_amount = if $token_from == $market_pair.base_asset { $amount_from } else { $amount_to };
-        let offer_quote_amount = if $token_from == $market_pair.base_asset { $amount_to } else { $amount_from };
+        let offer_base_amount = if $token_from == $market_pair.base_asset {
+          $amount_from
+        } else {
+          $amount_to
+        };
+        let offer_quote_amount = if $token_from == $market_pair.base_asset {
+          $amount_to
+        } else {
+          $amount_from
+        };
 
         assert_swap_work!(
           market_order,
@@ -196,7 +216,7 @@ mod tests {
       quote_asset: Asset::USDCoin.currency_id(),
     }
   );
- 
+
   // BTC_ETH
   test!(
     slippage_5_dot_9_eth_to_0_dot_9_btc,

--- a/primitives/src/swap/test.rs
+++ b/primitives/src/swap/test.rs
@@ -16,126 +16,83 @@
 
 #[macro_export]
 macro_rules! assert_swap_work {
-  ($market_order:expr, $limit_order:expr, $market_maker_amount_to_receive:expr, $market_maker_amount_to_send:expr) => {{
+  ($market_order:expr, $limit_order:expr, $offer_base_amount:expr, $offer_quote_amount:expr, $market_pair:expr) => {{
     let one_percent = Permill::from_rational(1_u128, 100_u128);
-    let two_percent = Permill::from_rational(2_u128, 100_u128);
-
-    let market_maker_amount_to_receive_more_1percent =
-      $market_maker_amount_to_receive.saturating_add(one_percent * $market_maker_amount_to_receive);
-    let market_maker_amount_to_receive_less_1percent =
-      $market_maker_amount_to_receive.saturating_sub(one_percent * $market_maker_amount_to_receive);
-
-    let market_maker_amount_to_receive_more_2percent =
-      $market_maker_amount_to_receive.saturating_add(two_percent * $market_maker_amount_to_receive);
-    let market_maker_amount_to_receive_less_2percent =
-      $market_maker_amount_to_receive.saturating_sub(two_percent * $market_maker_amount_to_receive);
-
-    let market_maker_amount_to_send_more_1percent =
-      $market_maker_amount_to_send.saturating_add(one_percent * $market_maker_amount_to_send);
-    let market_maker_amount_to_send_less_1percent =
-      $market_maker_amount_to_send.saturating_sub(one_percent * $market_maker_amount_to_send);
-
-    let market_maker_amount_to_send_more_2percent =
-      $market_maker_amount_to_send.saturating_add(two_percent * $market_maker_amount_to_send);
-    let market_maker_amount_to_send_less_2percent =
-      $market_maker_amount_to_send.saturating_sub(two_percent * $market_maker_amount_to_send);
+    let one_millionth = Permill::from_rational(1_u128, 1_000_000_u128);
+    let offer_quote_amount_1percent_more = $offer_quote_amount.saturating_add(one_percent * $offer_quote_amount);
+    let offer_quote_amount_1percent_less = $offer_quote_amount.saturating_sub(one_percent * $offer_quote_amount);
+    let offer_quote_amount_excceded_upperbound = offer_quote_amount_1percent_more.saturating_add(one_millionth * $offer_quote_amount);
+    let offer_quote_amount_excceded_lowerbound = offer_quote_amount_1percent_less.saturating_sub(one_millionth * $offer_quote_amount);
 
     // should pass with exact numbers
     assert_eq!(
       $market_order.validate_slippage(
         &$limit_order,
-        $market_maker_amount_to_receive,
-        $market_maker_amount_to_send
+        $offer_base_amount,
+        $offer_quote_amount,
+        &$market_pair,
       ),
       Ok(())
     );
 
-    // should pass with minimum numbers
+    // should pass with the minimum seller acceptable price
     assert_eq!(
       $market_order.validate_slippage(
         &$limit_order,
-        market_maker_amount_to_receive_more_1percent,
-        $market_maker_amount_to_send
-      ),
-      Ok(())
-    );
-    assert_eq!(
-      $market_order.validate_slippage(
-        &$limit_order,
-        $market_maker_amount_to_receive,
-        market_maker_amount_to_send_more_1percent
+        $offer_base_amount,
+        offer_quote_amount_1percent_less,
+        &$market_pair,
       ),
       Ok(())
     );
 
+    // should pass with the maximum buyer acceptable price
     assert_eq!(
       $market_order.validate_slippage(
         &$limit_order,
-        market_maker_amount_to_receive_less_1percent,
-        $market_maker_amount_to_send
-      ),
-      Ok(())
-    );
-    assert_eq!(
-      $market_order.validate_slippage(
-        &$limit_order,
-        $market_maker_amount_to_receive,
-        market_maker_amount_to_send_less_1percent
+        $offer_base_amount,
+        offer_quote_amount_1percent_more,
+        &$market_pair,
       ),
       Ok(())
     );
 
-    // should fails (2% slippage)
+    // should fail with a price lower than the minimum seller acceptable price
     assert_eq!(
       $market_order.validate_slippage(
         &$limit_order,
-        market_maker_amount_to_receive_more_2percent,
-        $market_maker_amount_to_send
+        $offer_base_amount,
+        offer_quote_amount_excceded_lowerbound,
+        &$market_pair,
       ),
-      Err(SlippageError::OfferIsLessThanSwapLowerBound)
-    );
-    assert_eq!(
-      $market_order.validate_slippage(
-        &$limit_order,
-        $market_maker_amount_to_receive,
-        market_maker_amount_to_send_more_2percent
-      ),
-      Err(SlippageError::OfferIsGreaterThanSwapUpperBound)
-    );
-
-    assert_eq!(
-      $market_order.validate_slippage(
-        &$limit_order,
-        $market_maker_amount_to_receive,
-        market_maker_amount_to_send_less_2percent
-      ),
-      Err(SlippageError::OfferIsLessThanSwapLowerBound)
-    );
-    assert_eq!(
-      $market_order.validate_slippage(
-        &$limit_order,
-        market_maker_amount_to_receive_less_2percent,
-        $market_maker_amount_to_send
-      ),
-      Err(SlippageError::OfferIsGreaterThanSwapUpperBound)
+      if ($market_pair.is_selling(&$limit_order).expect("market pair should be found in swap")
+        && $limit_order.is_market_maker)
+        || ($market_pair.is_selling(&$market_order).expect("market pair should be found in swap")
+        && $market_order.is_market_maker)
+      {
+        Err(SlippageError::OfferIsLessThanMarketMakerSwapLowerBound)  
+      } else {
+        Err(SlippageError::OfferIsLessThanSwapLowerBound)
+      }
     );
 
+    // should fail with a price higher than maximum buyer acceptable price
     assert_eq!(
       $market_order.validate_slippage(
         &$limit_order,
-        market_maker_amount_to_receive_less_1percent.saturating_sub(100),
-        $market_maker_amount_to_send
+        $offer_base_amount,
+        offer_quote_amount_excceded_upperbound,
+        &$market_pair,
       ),
-      Err(SlippageError::OfferIsGreaterThanSwapUpperBound)
-    );
-
-    assert_eq!(
-      $market_order.validate_slippage(
-        &$limit_order,
-        $market_maker_amount_to_receive,
-        market_maker_amount_to_send_less_1percent.saturating_sub(100)
-      ),
-      Err(SlippageError::OfferIsLessThanSwapLowerBound)
+      if (!$market_pair.is_selling(&$limit_order).expect("market pair should be found in swap")
+        && $limit_order.is_market_maker)
+        || (!$market_pair.is_selling(&$market_order).expect("market pair should be found in swap")
+        && $market_order.is_market_maker)
+      {
+        Err(SlippageError::OfferIsGreaterThanMarketMakerSwapUpperBound)
+      } else {
+        Err(SlippageError::OfferIsGreaterThanSwapUpperBound)
+      }
     );
   }};
 }
@@ -175,11 +132,12 @@ mod tests {
   }
 
   macro_rules! test {
-    ($func:ident, $token_from:expr, $amount_from:expr, $token_to:expr, $amount_to:expr) => {
+    ($func:ident, $token_from:expr, $amount_from:expr, $token_to:expr, $amount_to:expr, $market_pair:expr) => {
       #[test]
       fn $func() {
         let one_percent = Permill::from_rational(1_u128, 100_u128);
 
+        // Market Maker Limited Swap
         let limit_order = build_test_swap(
           AccountId::from_str(ALICE).unwrap(),
           SwapType::Limit,
@@ -190,7 +148,7 @@ mod tests {
           one_percent,
         );
 
-        // The chain will allow 99 TDFY/BTC and 101 TDFY/BTC (1% slippage)
+        // Trader Market Swap
         let market_order = build_test_swap(
           AccountId::from_str(BOB).unwrap(),
           SwapType::Market,
@@ -201,44 +159,45 @@ mod tests {
           one_percent,
         );
 
-        let market_maker_amount_to_receive = $amount_from;
-        let market_maker_amount_to_send = $amount_to;
+        let offer_base_amount = if $token_from == $market_pair.base_asset { $amount_from } else { $amount_to };
+        let offer_quote_amount = if $token_from == $market_pair.base_asset { $amount_to } else { $amount_from };
 
         assert_swap_work!(
           market_order,
           limit_order,
-          market_maker_amount_to_receive,
-          market_maker_amount_to_send
+          offer_base_amount,
+          offer_quote_amount,
+          $market_pair
         )
       }
     };
   }
 
-  // all tests
+  // ATH_USDC
   test!(
-    slippage_1_btc_to_100_tdfy,
-    Asset::Bitcoin.currency_id(),
-    Asset::Bitcoin.saturating_mul(1),
-    Asset::Tdfy.currency_id(),
-    Asset::Tdfy.saturating_mul(100)
+    slippage_1_000_ath_to_10_usdc,
+    Asset::AllTimeHigh.currency_id(),
+    Asset::AllTimeHigh.saturating_mul(1_000),
+    Asset::USDCoin.currency_id(),
+    Asset::USDCoin.saturating_mul(10),
+    MarketPair {
+      base_asset: Asset::AllTimeHigh.currency_id(),
+      quote_asset: Asset::USDCoin.currency_id(),
+    }
   );
-
   test!(
-    slippage_14_btc_to_2_900_000_tdfy,
-    Asset::Bitcoin.currency_id(),
-    Asset::Bitcoin.saturating_mul(14),
-    Asset::Tdfy.currency_id(),
-    Asset::Tdfy.saturating_mul(2_900_000)
+    slippage_10_usdc_to_1_000_ath,
+    Asset::USDCoin.currency_id(),
+    Asset::USDCoin.saturating_mul(10),
+    Asset::AllTimeHigh.currency_id(),
+    Asset::AllTimeHigh.saturating_mul(1_000),
+    MarketPair {
+      base_asset: Asset::AllTimeHigh.currency_id(),
+      quote_asset: Asset::USDCoin.currency_id(),
+    }
   );
-
-  test!(
-    slippage_5_eth_to_24_700_tdfy,
-    Asset::Ethereum.currency_id(),
-    Asset::Ethereum.saturating_mul(5),
-    Asset::Tdfy.currency_id(),
-    Asset::Tdfy.saturating_mul(24_700)
-  );
-
+ 
+  // BTC_ETH
   test!(
     slippage_5_dot_9_eth_to_0_dot_9_btc,
     Asset::Ethereum.currency_id(),
@@ -248,6 +207,156 @@ mod tests {
       .saturating_sub(100_000_000_000_000_000),
     Asset::Bitcoin.currency_id(),
     // 0.9 BTC
-    Asset::Bitcoin.saturating_mul(1).saturating_sub(10_000_000)
+    Asset::Bitcoin.saturating_mul(1).saturating_sub(10_000_000),
+    MarketPair {
+      base_asset: Asset::Bitcoin.currency_id(),
+      quote_asset: Asset::Ethereum.currency_id(),
+    }
+  );
+  test!(
+    slippage_0_dot_9_btc_to_5_dot_9_eth,
+    Asset::Bitcoin.currency_id(),
+    // 0.9 BTC
+    Asset::Bitcoin.saturating_mul(1).saturating_sub(10_000_000),
+    Asset::Ethereum.currency_id(),
+    // 5.9 ETH
+    Asset::Ethereum
+      .saturating_mul(6)
+      .saturating_sub(100_000_000_000_000_000),
+    MarketPair {
+      base_asset: Asset::Bitcoin.currency_id(),
+      quote_asset: Asset::Ethereum.currency_id(),
+    }
+  );
+
+  // BTC_USDC
+  test!(
+    slippage_1_btc_to_30_000_usdc,
+    Asset::Bitcoin.currency_id(),
+    Asset::Bitcoin.saturating_mul(1),
+    Asset::USDCoin.currency_id(),
+    Asset::USDCoin.saturating_mul(30_000),
+    MarketPair {
+      base_asset: Asset::Bitcoin.currency_id(),
+      quote_asset: Asset::USDCoin.currency_id(),
+    }
+  );
+  test!(
+    slippage_30_000_usdc_to_1_btc,
+    Asset::USDCoin.currency_id(),
+    Asset::USDCoin.saturating_mul(30_000),
+    Asset::Bitcoin.currency_id(),
+    Asset::Bitcoin.saturating_mul(1),
+    MarketPair {
+      base_asset: Asset::Bitcoin.currency_id(),
+      quote_asset: Asset::USDCoin.currency_id(),
+    }
+  );
+
+  // ETH_USDC
+  test!(
+    slippage_5_eth_to_2_900_usdc,
+    Asset::Ethereum.currency_id(),
+    Asset::Ethereum.saturating_mul(5),
+    Asset::USDCoin.currency_id(),
+    Asset::USDCoin.saturating_mul(2_900),
+    MarketPair {
+      base_asset: Asset::Ethereum.currency_id(),
+      quote_asset: Asset::USDCoin.currency_id(),
+    }
+  );
+  test!(
+    slippage_2_900_usdc_to_5_eth,
+    Asset::USDCoin.currency_id(),
+    Asset::USDCoin.saturating_mul(2_900),
+    Asset::Ethereum.currency_id(),
+    Asset::Ethereum.saturating_mul(5),
+    MarketPair {
+      base_asset: Asset::Ethereum.currency_id(),
+      quote_asset: Asset::USDCoin.currency_id(),
+    }
+  );
+
+  // TDFY_BTC
+  test!(
+    slippage_1_btc_to_100_tdfy,
+    Asset::Bitcoin.currency_id(),
+    Asset::Bitcoin.saturating_mul(1),
+    Asset::Tdfy.currency_id(),
+    Asset::Tdfy.saturating_mul(100),
+    MarketPair {
+      base_asset: Asset::Tdfy.currency_id(),
+      quote_asset: Asset::Bitcoin.currency_id(),
+    }
+  );
+  test!(
+    slippage_14_btc_to_2_900_000_tdfy,
+    Asset::Bitcoin.currency_id(),
+    Asset::Bitcoin.saturating_mul(14),
+    Asset::Tdfy.currency_id(),
+    Asset::Tdfy.saturating_mul(2_900_000),
+    MarketPair {
+      base_asset: Asset::Tdfy.currency_id(),
+      quote_asset: Asset::Bitcoin.currency_id(),
+    }
+  );
+  test!(
+    slippage_100_tdfy_to_1_btc,
+    Asset::Tdfy.currency_id(),
+    Asset::Tdfy.saturating_mul(100),
+    Asset::Bitcoin.currency_id(),
+    Asset::Bitcoin.saturating_mul(1),
+    MarketPair {
+      base_asset: Asset::Tdfy.currency_id(),
+      quote_asset: Asset::Bitcoin.currency_id(),
+    }
+  );
+
+  // TDFY_ETH
+  test!(
+    slippage_5_eth_to_24_700_tdfy,
+    Asset::Ethereum.currency_id(),
+    Asset::Ethereum.saturating_mul(5),
+    Asset::Tdfy.currency_id(),
+    Asset::Tdfy.saturating_mul(24_700),
+    MarketPair {
+      base_asset: Asset::Tdfy.currency_id(),
+      quote_asset: Asset::Ethereum.currency_id(),
+    }
+  );
+  test!(
+    slippage_24_700_tdfy_to_5_eth,
+    Asset::Tdfy.currency_id(),
+    Asset::Tdfy.saturating_mul(24_700),
+    Asset::Ethereum.currency_id(),
+    Asset::Ethereum.saturating_mul(5),
+    MarketPair {
+      base_asset: Asset::Tdfy.currency_id(),
+      quote_asset: Asset::Ethereum.currency_id(),
+    }
+  );
+
+  // TDFY_USDC
+  test!(
+    slippage_1_000_tdfy_to_2_900_usdc,
+    Asset::Tdfy.currency_id(),
+    Asset::Tdfy.saturating_mul(1_000),
+    Asset::USDCoin.currency_id(),
+    Asset::USDCoin.saturating_mul(2_900),
+    MarketPair {
+      base_asset: Asset::Tdfy.currency_id(),
+      quote_asset: Asset::USDCoin.currency_id(),
+    }
+  );
+  test!(
+    slippage_2_900_usdc_to_1_000_tdfy,
+    Asset::USDCoin.currency_id(),
+    Asset::USDCoin.saturating_mul(2_900),
+    Asset::Tdfy.currency_id(),
+    Asset::Tdfy.saturating_mul(1_000),
+    MarketPair {
+      base_asset: Asset::Tdfy.currency_id(),
+      quote_asset: Asset::USDCoin.currency_id(),
+    }
   );
 }


### PR DESCRIPTION
The following changes have been made:
- Created a MarketPair struct in swap.rs file and use it to decide if the swap is selling or buying the base asset. 
- Updated `validate_slippage` logic with market pair
- Updated all the tests for slippage validation.

Reference: tidechain [PR-356](https://github.com/tidelabs/tidechain/issues/356)

Tests Results:
```
running 16 tests
test assets::tests::test_saturation_of_assets ... ok
test swap::test::tests::slippage_1_000_ath_to_10_usdc ... ok
test swap::test::tests::slippage_1_btc_to_100_tdfy ... ok
test swap::test::tests::slippage_100_tdfy_to_1_btc ... ok
test swap::test::tests::slippage_0_dot_9_btc_to_5_dot_9_eth ... ok
test swap::test::tests::slippage_1_btc_to_30_000_usdc ... ok
test swap::test::tests::slippage_10_usdc_to_1_000_ath ... ok
test swap::test::tests::slippage_14_btc_to_2_900_000_tdfy ... ok
test swap::test::tests::slippage_1_000_tdfy_to_2_900_usdc ... ok
test swap::test::tests::slippage_24_700_tdfy_to_5_eth ... ok
test swap::test::tests::slippage_2_900_usdc_to_1_000_tdfy ... ok
test swap::test::tests::slippage_5_dot_9_eth_to_0_dot_9_btc ... ok
test swap::test::tests::slippage_2_900_usdc_to_5_eth ... ok
test swap::test::tests::slippage_30_000_usdc_to_1_btc ... ok
test swap::test::tests::slippage_5_eth_to_2_900_usdc ... ok
test swap::test::tests::slippage_5_eth_to_24_700_tdfy ... ok
```